### PR TITLE
New Feature: Add logging to Syslog for fail2ban to block offending clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ config/pubkey.pem
 !*js/functions.js
 js/jquery-1.11.2.min.map
 msg.po
+
+# Eclipse specific files
+.buildpath
+.project
+.settings

--- a/ajax/ajax_configSave.php
+++ b/ajax/ajax_configSave.php
@@ -63,6 +63,7 @@ if ($actionId === SP\Controller\ActionsInterface::ACTION_CFG_GENERAL
         $siteTheme = SP\Request::analyze('sitetheme', 'material-blue');
         $sessionTimeout = SP\Request::analyze('session_timeout', 300);
         $httpsEnabled = SP\Request::analyze('https_enabled', false, false, true);
+        $fail2banEnabled = SP\Request::analyze('fail2ban_enabled', false, false, true);
         $logEnabled = SP\Request::analyze('log_enabled', false, false, true);
         $debugEnabled = SP\Request::analyze('debug', false, false, true);
         $maintenanceEnabled = SP\Request::analyze('maintenance', false, false, true);
@@ -73,6 +74,7 @@ if ($actionId === SP\Controller\ActionsInterface::ACTION_CFG_GENERAL
         SP\Config::setCacheConfigValue('sitetheme', $siteTheme);
         SP\Config::setCacheConfigValue('session_timeout', $sessionTimeout);
         SP\Config::setCacheConfigValue('https_enabled', $httpsEnabled);
+        SP\Config::setCacheConfigValue('fail2ban_enabled', $fail2banEnabled);
         SP\Config::setCacheConfigValue('log_enabled', $logEnabled);
         SP\Config::setCacheConfigValue('debug', $debugEnabled);
         SP\Config::setCacheConfigValue('maintenance', $maintenanceEnabled);

--- a/config/config.php.sample
+++ b/config/config.php.sample
@@ -13,6 +13,7 @@ $CONFIG = array (
   'dbuser' => 'sp_admin',
   'debug' => 0,
   'demo_enabled' => 0,
+  'fail2ban_enabled' => 0,
   'files_enabled' => 1,
   'globalsearch' => 1,
   'installed' => 0,

--- a/inc/Config.class.php
+++ b/inc/Config.class.php
@@ -195,6 +195,7 @@ class Config implements ConfigInterface
         self::setCacheConfigValue('proxy_port', '');
         self::setCacheConfigValue('proxy_user', '');
         self::setCacheConfigValue('proxy_pass', '');
+        self::setCacheConfigValue('fail2ban_enabled', false);
 
         self::writeConfig();
     }

--- a/inc/themes/material-blue/config.inc
+++ b/inc/themes/material-blue/config.inc
@@ -82,6 +82,24 @@
             </tr>
             <tr>
                 <td class="descField">
+                    <?php echo _('Activar Fail2Ban'); ?>
+                    <div id="help-fail2ban" class="icon material-icons fg-blue80">help_outline</div>
+                    <div class="mdl-tooltip mdl-tooltip--large" for="help-fail2ban">
+                        <p>
+                            <?php echo _('Activar Fail2Ban - Description'); ?>
+                        </p>
+                    </div>
+                </td>
+                <td class="valField">
+                    <label class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="fail2ban_enabled">
+                        <input type="checkbox" id="fail2ban_enabled" class="mdl-switch__input fg-blue100" name="fail2ban_enabled"
+                            <?php echo $chkFail2ban, ' ', $isDisabled; ?>/>
+                        <span class="mdl-switch__label"></span>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td class="descField">
                     <?php echo _('Habilitar log de eventos'); ?>
                     <div id="help-eventlog" class="icon material-icons fg-blue80">help_outline</div>
                     <div class="mdl-tooltip mdl-tooltip--large" for="help-eventlog">

--- a/web/ConfigC.class.php
+++ b/web/ConfigC.class.php
@@ -79,6 +79,7 @@ class ConfigC extends Controller implements ActionsInterface
         $this->view->assign('themesAvailable', Themes::getThemesAvailable());
         $this->view->assign('currentTheme', \SP\Config::getValue('sitetheme'));
         $this->view->assign('chkHttps', (\SP\Config::getValue('https_enabled')) ? 'checked="checked"' : '');
+        $this->view->assign('chkFail2ban', (\SP\Config::getValue('fail2ban_enabled')) ? 'checked="checked"' : '');
         $this->view->assign('chkLog', (\SP\Config::getValue('log_enabled')) ? 'checked="checked"' : '');
         $this->view->assign('chkDebug', (\SP\Config::getValue('debug')) ? 'checked="checked"' : '');
         $this->view->assign('chkMaintenance', (\SP\Config::getValue('maintenance')) ? 'checked="checked"' : '');


### PR DESCRIPTION
Hi,

I found sysPASS on my search for an on-premise secure password storage and find it quite useful and fitting. There is one feature that I find missing: Since I want do put the software on a public facing host, I want to block clients with too many failed password attempts using fail2ban.
Here is a full implementation of it, complete with an option in the settings menu, Since I haven't worked with gettext before, here are the English and German translation for the two new language keys: https://gist.github.com/wendelb/252727936e62801e631b7fb1fe8cb06f

For fail2ban to work, the configuration needs to be ammended. All needed new files are here: https://gist.github.com/wendelb/090f219dd151225d2c8e83763873d7a5 - You might want to put them on the wiki.

There isn't much for documentation. Once the new switch is enabled, failed login attempts will be reported to syslog and written to `/var/log/auth.log` (depending on your platform and configuration).

Kind regards
Bernhard Wendel
