### PR TITLE
Add API Request Signature

### DIFF
--- a/addapisignature.sql
+++ b/addapisignature.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `authTokens` ADD COLUMN
+(
+    `authtoken_secret` varchar(64) NOT NULL
+) 
+AFTER `authtoken_token`;

--- a/inc/ApiRequest.class.php
+++ b/inc/ApiRequest.class.php
@@ -41,6 +41,8 @@ class ApiRequest extends Request
     const ITEM = 'i';
     const SEARCH = 's';
     const SEARCH_COUNT = 'sc';
+    const REQUEST_SIGNATURE = 'rs';
+    const REQUEST_TIMESTAMP = 'rt';
 
     /**
      * @var \stdClass
@@ -49,13 +51,17 @@ class ApiRequest extends Request
 
     public function __construct(){
         $authToken = self::analyze(self::AUTH_TOKEN);
+        $reqSignature = self::analyze(self::REQUEST_SIGNATURE);
+        $reqTimestamp = self::analyze(self::REQUEST_TIMESTAMP);
         $actionId = self::analyze(self::ACTION_ID, 0);
 
-        if (!$authToken || !$actionId){
+        if (!$authToken || !$actionId || !$reqSignature){
             throw new SPException(SPException::SP_WARNING, _('Parámetros incorrectos'));
         }
 
         $this->addVar('authToken', $authToken);
+        $this->addVar('reqSignature', $reqSignature);
+        $this->addVar('reqTimestamp', $reqTimestamp);
         $this->addVar('actionId', $actionId);
         $this->addVar('userPass', null);
     }
@@ -78,7 +84,7 @@ class ApiRequest extends Request
      */
     public function getApi()
     {
-        return new Api($this->_vars->actionId, $this->_vars->authToken, $this->_vars->userPass);
+        return new Api($this->_vars->actionId, $this->_vars->authToken, $this->_vars->reqSignature, $this->_vars->reqTimestamp, $this->_vars->userPass);
     }
 
     /**

--- a/inc/themes/material-blue/mgmttabs.inc
+++ b/inc/themes/material-blue/mgmttabs.inc
@@ -37,7 +37,7 @@
         <div class="data-rows">
             <?php foreach ($tab['query'] as $item): ?>
                 <?php $i = 0; ?>
-                <?php $itemId = $item->$tab['props']['tblRowSrcId']; ?>
+                <?php $itemId = $item->{$tab['props']['tblRowSrcId']}; ?>
                 <?php $action_check = array(); ?>
                 <ul>
                     <?php foreach ($tab['props']['tblRowSrc'] as $type => $rowSrc): ?>

--- a/inc/themes/material-blue/tokens.inc
+++ b/inc/themes/material-blue/tokens.inc
@@ -46,6 +46,10 @@
                     <td class="descField"><?php echo _('Token'); ?></td>
                     <td class="valField"><?php echo ($gotData) ? $token->authtoken_token : ''; ?></td>
                 </tr>
+				<tr>
+                    <td class="descField"><?php echo _('Secret'); ?></td>
+                    <td class="valField"><?php echo ($gotData) ? $token->authtoken_secret : ''; ?></td>
+                </tr>
             <?php endif; ?>
             </tbody>
         </table>

--- a/web/UsersMgmtC.class.php
+++ b/web/UsersMgmtC.class.php
@@ -451,6 +451,7 @@ class UsersMgmtC extends Controller implements ActionsInterface
         $this->view->assign('users', \SP\DB::getValuesForSelect('usrData', 'user_id', 'user_name'));
         $this->view->assign('actions', \SP\ApiTokens::getTokenActions());
         $this->view->assign('token', $token);
+        $this->view->assign('secret', $secret);
         $this->view->assign('gotData', is_object($token));
 
         if ($this->view->isView === true) {


### PR DESCRIPTION
Currently, there seems to be an open vulnerability when using the API functionality. A valid request involves a token and password being sent in the URL of the request. This request URL does not expire or invalidate, meaning that if someone were to get the URL they can replay the attack indefinitely by changing a few parameters.

To fix this I propose adding two pieces of functionality. First, a token is used only to identify the user. Second, a shared secret is added to the token functionality. Third, a request timestamp is added.

A normal request would be:
https://www.example.info/sysPass/api.php?t=063c8cc5798b7241052aef1ee85690fd09885aad&a=3&i=2&up=MYSUPERSECRETPASSWORD

I propose it would function more like so:
Assume my shared secret is SUPERSHAREDSECRET

First, a request message is created as such:
<method>&[<sorted key, value parameters>]
GET&a=3&i=2&t=063c8cc5798b7241052aef1ee85690fd09885aad&rt=1476898952

I then run that through a SHA-256 HMAC and hex-encode the result. This equals:
17adf85c2c47238b3c922a22cd6a262369db6f5796cc1fa8212b26ff82bbc537

I then setup my request like so:
https://www.example.info/sysPass/api.php?a=3&i=2&t=063c8cc5798b7241052aef1ee85690fd09885aad&rt=1476898952&rs=17adf85c2c47238b3c922a22cd6a262369db6f5796cc1fa8212b26ff82bbc537

The server receives the request. Pulls the shared secret from the database. Recreates the first step, signs it, and compares the signature. If the signature matches, it moves forward, if not, then it throws an exception. Additionally, the timestamp (defined in rt) is checked to ensure that it falls within a certain time-frame, in the case of my changes 5 minutes on either side, totaling 10 minutes. This can be changed to a smaller timeframe, say a few seconds or so, to prevent a replay attack window.

This is my first pull request, so hopefully I did OK explaining the situation and what it would fix.
