### PR TITLE
Solve ticket #319

### DIFF
--- a/inc/themes/classic/sessionbar.inc
+++ b/inc/themes/classic/sessionbar.inc
@@ -1,13 +1,11 @@
 <div id="header">
     <div id="session" class="midround shadow">
+		    <?php printf('%s (%s) %s', $userName, $userGroup, $adminApp); ?>
         <?php if ($showPassIcon): ?>
-            <?php echo $userName, ' (', $userGroup, ') ', $adminApp; ?>
             <img src="imgs/key.png" class="iconMini"
                 title="<?php echo _('Cambiar clave de usuario'); ?>"
                 data-itemid="<?php echo $userId; ?>"
                 Onclick="sysPassUtil.Common.usrUpdPass(this,<?php echo \SP\Controller\ActionsInterface::ACTION_USR_USERS_EDITPASS; ?>, '<?php echo $sk; ?>')" />
-        <?php else: ?>
-            <?php echo $userName, ' (', $userGroupName, ') ', $adminApp; ?>
         <?php endif; ?>
         <img src="imgs/preferences.png" class="iconMini" title="<?php echo _('Preferencias'); ?>"
              data-itemid="<?php echo $userId; ?>"

--- a/inc/themes/classic/sessionbar.inc
+++ b/inc/themes/classic/sessionbar.inc
@@ -1,6 +1,6 @@
 <div id="header">
     <div id="session" class="midround shadow">
-		    <?php printf('%s (%s) %s', $userName, $userGroup, $adminApp); ?>
+            <?php printf('%s (%s) %s', $userName, $userGroup, $adminApp); ?>
         <?php if ($showPassIcon): ?>
             <img src="imgs/key.png" class="iconMini"
                 title="<?php echo _('Cambiar clave de usuario'); ?>"


### PR DESCRIPTION
In classic theme, if the user does not display the pass icon, group name
and administrateur flag are not display in the session bar, in top of
page.

Change the sessionbar.inc, in classic theme, wit a copy of what is done
from the footer.ing file in the Material Blue theme.