### PR TITLE
Solve issue #325, Custom field creation, "empty" type list in theme classic

### DIFF
--- a/inc/themes/classic/customfields.inc
+++ b/inc/themes/classic/customfields.inc
@@ -18,7 +18,7 @@
                     <select name="type" id="sel-type" size="1" class="sel-chosen-ns">
                         <?php foreach ($types as $id => $type): ?>
                             <option
-                                value='<?php echo $id; ?>' <?php echo ($gotData && $id === $field->getType()) ? 'selected' : ''; ?>><?php echo strtoupper($type); ?></option>
+                                value='<?php echo $id; ?>' <?php echo ($gotData && $id === $field->getType()) ? 'selected' : ''; ?>><?php echo $type[1]; ?></option>
                         <?php endforeach; ?>
                     </select>
                 </td>
@@ -29,7 +29,7 @@
                     <select name="module" id="sel-module" size="1" class="sel-chosen-ns">
                         <?php foreach ($modules as $id => $module): ?>
                             <option
-                                value='<?php echo $id; ?>' <?php echo ($gotData && $id === $field->getModule()) ? 'selected' : ''; ?>><?php echo strtoupper($module); ?></option>
+                                value='<?php echo $id; ?>' <?php echo ($gotData && $id === $field->getModule()) ? 'selected' : ''; ?>><?php echo $module; ?></option>
                         <?php endforeach; ?>
                     </select>
                 </td>


### PR DESCRIPTION
Issue #325 For classic theme, the type list is empty for the custom field creation form.
Not the case in Material Blue. Reproduce the same code.
Previously in Classic theme, modules labels were put in uppercase. Not the case in Material Blue.