### PR TITLE
PHP 7 is more strict than PHP 5

### DIFF
--- a/inc/SP/Mgmt/Users/UserPassRecover.class.php
+++ b/inc/SP/Mgmt/Users/UserPassRecover.class.php
@@ -212,4 +212,26 @@ class UserPassRecover extends UserPassRecoverBase implements ItemInterface
     {
         // TODO: Implement checkDuplicatedOnAdd() method.
     }
+
+    /**
+     * Eliminar elementos en lote
+     *
+     * @param array $ids
+     * @return $this
+     */
+    public function deleteBatch(array $ids)
+    {
+        // TODO: Implement deleteBatch() method.
+    }
+
+    /**
+     * Devolver los elementos con los ids especificados
+     *
+     * @param array $ids
+     * @return mixed
+     */
+    public function getByIdBatch(array $ids)
+    {
+        // TODO: Implement getByIdBatch() method.
+    }
 }


### PR DESCRIPTION
Got this error message:
```
PHP Fatal error:  Class SP\\Mgmt\\Users\\UserPassRecover contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (SP\\Mgmt\\ItemInterface::deleteBatch, SP\\Mgmt\\ItemInterface::getByIdBatch) in [...]/syspass/inc/SP/Mgmt/Users/UserPassRecover.class.php on line 41
```

Add skeleton of not implemented abstract functions so PHP 7 recognises the `SP\Mgmt\Users\UserPassRecover` as non-abstract without inheriting `SP\Mgmt\ItemInterface`