### PR TITLE
[FIX] Constant BASE_DIR already defined

### DIFF
--- a/inc/Base.php
+++ b/inc/Base.php
@@ -26,8 +26,6 @@ use SP\Core\Init;
 
 defined('APP_ROOT') || die();
 
-define('BASE_DIR', __DIR__);
-//
 // Please, notice that this file should be outside the webserver root. You can move it and then update this path
 define('XML_CONFIG_FILE', __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config.xml');
 


### PR DESCRIPTION
Fixes error:
`Notice: Constant BASE_DIR already defined in /var/www/html/syspass/inc/Base.php on line 34`

Constant BASE_DIR defined on line 29 and 34.