### PR TITLE
Typo in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -26,7 +26,7 @@ Instalación y preguntas frecuentes en http://wiki.syspass.org
 
 ---
 
-Installation and Frequently Asked Questions at at http://wiki.syspass.org
+Installation and Frequently Asked Questions at http://wiki.syspass.org
 
 ---
 


### PR DESCRIPTION
The extra "at" is grammatically incorrect. The link also points to wiki.syspass.org instead of doc.syspass.org but of course wiki.syspass.org will still work.