### PR TITLE
Syslog setIsRemote cast to bool

### DIFF
--- a/inc/SP/Log/Syslog.class.php
+++ b/inc/SP/Log/Syslog.class.php
@@ -45,7 +45,7 @@ class Syslog extends AbstractLogger
      */
     public function setIsRemote($isRemote)
     {
-        $this->isRemote = $isRemote;
+        $this->isRemote = (bool)$isRemote;
     }
 
     /**


### PR DESCRIPTION
Sometimes, isRemote will be set to int(0), which tricks the syslog class to think that isRemote is enabled (the isRemote === false test)

I think this int comes from the xml file, since the code that reads it doesn't have means to know what type it should be.

A better fix is perhaps to cast to the right type as the configuration is being read from xml, but as a quick fix this worked fine.

The patch is up-ported from 2.1.16, so if it has been fixed elsewhere already, please disregard this pull request :)