### PR TITLE
Remove UserAccountControl to support Azure AD

### DIFF
--- a/inc/SP/Auth/Ldap/LdapMsAds.class.php
+++ b/inc/SP/Auth/Ldap/LdapMsAds.class.php
@@ -52,7 +52,7 @@ class LdapMsAds extends LdapBase
 
         $groupDN = ldap_escape($this->searchGroupDN());
 
-        return '(&(|(memberOf=' . $groupDN . ')(groupMembership=' . $groupDN . ')(memberof:1.2.840.113556.1.4.1941:=' . $groupDN . '))(!(UserAccountControl:1.2.840.113556.1.4.804:=34))(|(objectClass=inetOrgPerson)(objectClass=person)(objectClass=simpleSecurityObject)))';
+        return '(&(|(memberOf=' . $groupDN . ')(groupMembership=' . $groupDN . ')(memberof:1.2.840.113556.1.4.1941:=' . $groupDN . '))(|(objectClass=inetOrgPerson)(objectClass=person)(objectClass=simpleSecurityObject)))';
     }
 
     /**


### PR DESCRIPTION
Azure AD does not support UserAccountControl. 
And the value is sometime different to AD compatible systems. My Proposal is to remove the filter.