### PR TITLE
[FIX] Restore icons for template.

### DIFF
--- a/lib/SP/Mvc/View/Template.php
+++ b/lib/SP/Mvc/View/Template.php
@@ -356,7 +356,11 @@ final class Template
             throw new FileNotFoundException(__('La plantilla no contiene archivos'));
         }
 
-        $icons = $this->vars->get('icons');
+        /**
+         * No more icons var.
+         * $icons = $this->vars->get('icons');
+         */
+        $icons = $this->theme->getIcons();
         $configData = $this->vars->get('configData');
         $sk = $this->vars->get('sk');
 


### PR DESCRIPTION
I updated sysPass to 3.0 beta and could not update the database because an error occurred on upgrade page.
```
[DEBUG] [SP \ Bootstrap :: SP \ {closure}] Routing error: getIconWarning () on zero
```
This was due to the fact that icons var is not set in the template.