### PR TITLE
Azure patch

### DIFF
--- a/app/modules/web/Controllers/ConfigLdapController.php
+++ b/app/modules/web/Controllers/ConfigLdapController.php
@@ -74,6 +74,7 @@ final class ConfigLdapController extends SimpleControllerBase
             if ($ldapEnabled) {
                 $configData->setLdapEnabled(true);
                 $configData->setLdapAds($ldapParams->isAds());
+                $configData->setLdapAzure($ldapParams->isAzure());
                 $configData->setLdapTlsEnabled($ldapParams->isTlsEnabled());
                 $configData->setLdapServer($ldapParams->getServer());
                 $configData->setLdapBase($ldapParams->getSearchBase());
@@ -129,6 +130,7 @@ final class ConfigLdapController extends SimpleControllerBase
             ->setBindDn($this->request->analyzeString('ldap_binduser'))
             ->setBindPass($this->request->analyzeEncrypted('ldap_bindpass'))
             ->setAds($this->request->analyzeBool('ldap_ads_enabled', false))
+            ->SetAzure($this->request->analyzeBool('ldap_azure_enabled', false))
             ->setTlsEnabled($this->request->analyzeBool('ldap_tls_enabled', false));
     }
 

--- a/app/modules/web/themes/material-blue/views/config/ldap.inc
+++ b/app/modules/web/themes/material-blue/views/config/ldap.inc
@@ -71,6 +71,23 @@
 
                     <li class="mdl-list__item mdl-list__item--two-line">
                         <div class="mdl-switch__box">
+                            <label class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="ldap_azure_enabled">
+                                <input type="checkbox" id="ldap_azure_enabled"
+                                       class="mdl-switch__input"
+                                       name="ldap_azure_enabled" <?php echo $configData->isLdapAzure() ? 'checked' : ''; ?>/>
+                            </label>
+                        </div>
+
+                        <span class="mdl-list__item-primary-content">
+                                <span><?php echo __('Azure Active Directory'); ?></span>
+                                <span class="mdl-list__item-sub-title">
+                                    <?php echo __('Disables empty password and disabled user account filters.'); ?>
+                                </span>
+                            </span>
+                    </li>
+
+                    <li class="mdl-list__item mdl-list__item--two-line">
+                        <div class="mdl-switch__box">
                             <label class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="ldap_tls_enabled">
                                 <input type="checkbox" id="ldap_tls_enabled"
                                        class="mdl-switch__input"

--- a/app/modules/web/themes/material-blue/views/config/ldap.inc
+++ b/app/modules/web/themes/material-blue/views/config/ldap.inc
@@ -79,7 +79,7 @@
                         </div>
 
                         <span class="mdl-list__item-primary-content">
-                                <span><?php echo __('Azure Active Directory'); ?></span>
+                                <span><?php echo __('Azure & Compatible Active Directory'); ?></span>
                                 <span class="mdl-list__item-sub-title">
                                     <?php echo __('Disables empty password and disabled user account filters.'); ?>
                                 </span>

--- a/lib/SP/Config/ConfigData.php
+++ b/lib/SP/Config/ConfigData.php
@@ -202,6 +202,10 @@ final class ConfigData implements JsonSerializable
      */
     private $ldapAds = false;
     /**
+     * @var bool
+     */
+    private $ldapAzure = false;
+    /**
      * @var string
      */
     private $ldapGroup;
@@ -1673,6 +1677,26 @@ final class ConfigData implements JsonSerializable
     public function setLdapAds($ldapAds)
     {
         $this->ldapAds = (bool)$ldapAds;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isLdapAzure()
+    {
+        return $this->ldapAzure;
+    }
+
+    /**
+     * @param boolean $ldapAzure
+     *
+     * @return $this
+     */
+    public function setLdapAzure($ldapAzure)
+    {
+        $this->ldapAzure = (bool)$ldapAzure;
 
         return $this;
     }

--- a/lib/SP/Providers/Auth/Ldap/LdapParams.php
+++ b/lib/SP/Providers/Auth/Ldap/LdapParams.php
@@ -64,6 +64,10 @@ final class LdapParams
     /**
      * @var bool
      */
+    protected $azure = false;
+    /**
+     * @var bool
+     */
     protected $tlsEnabled = false;
 
     /**
@@ -210,6 +214,26 @@ final class LdapParams
     public function setAds($ads)
     {
         $this->ads = (bool)$ads;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAzure()
+    {
+        return $this->azure;
+    }
+
+    /**
+     * @param bool $azure
+     *
+     * @return LdapParams
+     */
+    public function setAzure($azure)
+    {
+        $this->azure= (bool)$azure;
 
         return $this;
     }


### PR DESCRIPTION
This patch resolves our discussion about #1050 by implementing the disabled and empty password user account filters again, but this time with a nice AD Azure option that allows them to be disabled.