### PR TITLE
Add new field AuthType in mail configuration

### DIFF
--- a/app/modules/web/Controllers/ConfigMailController.php
+++ b/app/modules/web/Controllers/ConfigMailController.php
@@ -65,6 +65,7 @@ final class ConfigMailController extends SimpleControllerBase
         $mailFrom = $this->request->analyzeEmail('mail_from');
         $mailRequests = $this->request->analyzeBool('mail_requests_enabled', false);
         $mailAuth = $this->request->analyzeBool('mail_auth_enabled', false);
+        $mailAuthtype = $this->request->analyzeString('mail_authtype');
         $mailRecipients = ConfigUtil::mailAddressesAdapter($this->request->analyzeString('mail_recipients'));
 
         // Valores para la configuración del Correo
@@ -89,6 +90,7 @@ final class ConfigMailController extends SimpleControllerBase
             if ($mailAuth) {
                 $configData->setMailAuthenabled($mailAuth);
                 $configData->setMailUser($mailUser);
+                $configData->setMailAuthtype($mailAuthtype);
 
                 if ($mailPass !== '***') {
                     $configData->setMailPass($mailPass);
@@ -135,6 +137,7 @@ final class ConfigMailController extends SimpleControllerBase
         $mailParams->security = $this->request->analyzeString('mail_security');
         $mailParams->from = $this->request->analyzeEmail('mail_from');
         $mailParams->mailAuthenabled = $this->request->analyzeBool('mail_auth_enabled', false);
+        $mailParams->mailAuthtype = $this->request->analyzeString('mail_authtype');
         $mailRecipients = ConfigUtil::mailAddressesAdapter($this->request->analyzeString('mail_recipients'));
 
         // Valores para la configuración del Correo

--- a/app/modules/web/Controllers/ConfigManagerController.php
+++ b/app/modules/web/Controllers/ConfigManagerController.php
@@ -246,6 +246,7 @@ final class ConfigManagerController extends ControllerBase
         $template->addTemplate('mail');
 
         $template->assign('mailSecurity', ['SSL', 'TLS']);
+        $template->assign('mailAuthTypes', ['PLAIN', 'LOGIN']);
         $template->assign('userGroups', SelectItemAdapter::factory(UserGroupService::getItemsBasic())->getItemsFromModel());
         $template->assign('userProfiles', SelectItemAdapter::factory(UserProfileService::getItemsBasic())->getItemsFromModel());
 

--- a/app/modules/web/themes/material-blue/views/config/mail.inc
+++ b/app/modules/web/themes/material-blue/views/config/mail.inc
@@ -103,6 +103,22 @@
         </tr>
         <tr>
             <td class="descField">
+                <?php echo __('Auth Type'); ?>
+            </td>
+            <td class="valField">
+                <div class="lowres-title"><?php echo __('Auth Type'); ?></div>
+
+                 <select name="mail_authtype" id="sel-mailsecurity" size="1" class="select-box select-box-deselect">
+                    <option value=""><?php echo __('Auth Type'); ?></option>
+                    <?php foreach ($_getvar('mailAuthTypes') as $authtype): ?>
+                        <option
+                                value="<?php echo $authtype; ?>" <?php echo ($configData->getMailAuthType() === $authtype) ? 'selected' : ''; ?>><?php echo $authtype; ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <td class="descField">
                 <?php echo __('User'); ?>
             </td>
             <td class="valField">

--- a/lib/SP/Config/ConfigData.php
+++ b/lib/SP/Config/ConfigData.php
@@ -226,6 +226,10 @@ final class ConfigData implements JsonSerializable
      */
     private $mailAuthenabled = false;
     /**
+     * @var string
+     */
+    private $mailAuthtype;
+    /**
      * @var bool
      */
     private $mailEnabled = false;
@@ -1279,6 +1283,25 @@ final class ConfigData implements JsonSerializable
         $this->mailAuthenabled = (bool)$mailAuthenabled;
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailAuthtype()
+    {
+        return $this->mailAuthtype;
+    }
+
+    /**
+     * @param string $mailAuthtype
+     *
+     * @return $this
+     */
+    public function setMailAuthtype($mailAuthtype)
+    {
+        $this->mailAuthtype = $mailAuthtype;
+         return $this;
     }
 
     /**

--- a/lib/SP/Providers/Mail/MailParams.php
+++ b/lib/SP/Providers/Mail/MailParams.php
@@ -59,4 +59,8 @@ final class MailParams
      * @var bool
      */
     public $mailAuthenabled;
+    /**
+     * @var string
+     */
+    public $mailAuthtype;
 }

--- a/lib/SP/Providers/Mail/MailProvider.php
+++ b/lib/SP/Providers/Mail/MailProvider.php
@@ -66,6 +66,7 @@ final class MailProvider extends Provider
 
             if ($mailParams->mailAuthenabled) {
                 $this->mailer->SMTPAuth = true;
+                $this->mailer->AuthType = $mailParams->mailAuthtype;
                 $this->mailer->Username = $mailParams->user;
                 $this->mailer->Password = $mailParams->pass;
             }

--- a/lib/SP/Services/Mail/MailService.php
+++ b/lib/SP/Services/Mail/MailService.php
@@ -207,6 +207,7 @@ final class MailService extends Service
         $mailParams->security = $configData->getMailSecurity();
         $mailParams->from = $configData->getMailFrom();
         $mailParams->mailAuthenabled = $configData->isMailAuthenabled();
+        $mailParams->mailAuthtype = $configData->getMailAuthtype();
 
         return $mailParams;
     }


### PR DESCRIPTION
# Problem

When I try to connect to my SMTP server (postal server selfhosted https://postal.atech.media), I get an error message "Could not authenticate". 
```json
{"status":1,"description":"Error al enviar el email","action":"","data":[],"messages":["SMTP Error: Could not authenticate."],"container":"","csrf":"************************************"}
```

# Solution

Add new field to set SMTP Auth type.

---

Thanks for your great job nuxmin ;)

----

Old closed PR: https://github.com/nuxsmin/sysPass/pull/1206