### PR TITLE
[FIX] msAds disabled users able to login

### DIFF
--- a/lib/SP/Providers/Auth/Ldap/LdapMsAds.php
+++ b/lib/SP/Providers/Auth/Ldap/LdapMsAds.php
@@ -38,7 +38,7 @@ use SP\Http\Address;
  */
 final class LdapMsAds extends Ldap
 {
-    const FILTER_USER_OBJECT = '(&(!(UserAccountControl:1.2.840.113556.1.4.804:=34))(|(objectCategory=person)(objectClass=user)))';
+    const FILTER_USER_OBJECT = '(&(!(UserAccountControl:1.2.840.113556.1.4.804:=32))(|(objectCategory=person)(objectClass=user)))';
     const FILTER_GROUP_OBJECT = '(objectCategory=group)';
     const FILTER_USER_ATTRIBUTES = ['samaccountname', 'cn', 'uid', 'userPrincipalName'];
     const FILTER_GROUP_ATTRIBUTES = ['memberOf', 'groupMembership', 'memberof:1.2.840.113556.1.4.1941:'];


### PR DESCRIPTION
Hello,

Based on the issue #1523, I removed the LDAP filter where the disabled users were "hidden" to sysPass, this way when the user is disabled sysPass is able to deny his request. 

I'm not sure if it's the better way to fix the problem, because sysPass has a function to import users from LDAP, and now disabled users will be import too. 