### PR TITLE
[ADD] Add "Main Group" in Permission Preset

### DIFF
--- a/app/modules/web/Controllers/Helpers/Account/AccountHelper.php
+++ b/app/modules/web/Controllers/Helpers/Account/AccountHelper.php
@@ -392,7 +392,7 @@ final class AccountHelper extends HelperBase
         $this->view->assign('otherUserGroupsEdit', $selectUserGroups->getItemsFromModelSelected($accountPermission->getUserGroupsEdit()));
 
         $this->view->assign('users', $selectUsers->getItemsFromModel());
-        $this->view->assign('userGroups', $selectUserGroups->getItemsFromModel());
+        $this->view->assign('userGroups', $selectUserGroups->getItemsFromModelSelected(array($accountPermission->getMainUsergroupId())));
         $this->view->assign('tags', $selectTags->getItemsFromModel());
 
         $this->view->assign('allowPrivate', $userProfileData->isAccPrivate() || $userData->getIsAdminApp());

--- a/app/modules/web/Controllers/Helpers/ItemPresetHelper.php
+++ b/app/modules/web/Controllers/Helpers/ItemPresetHelper.php
@@ -74,6 +74,7 @@ final class ItemPresetHelper extends HelperBase
         $this->view->assign('usersEdit', $this->users->getItemsFromModelSelected($accountPermission->getUsersEdit()));
         $this->view->assign('userGroupsView', $this->userGroups->getItemsFromModelSelected($accountPermission->getUserGroupsView()));
         $this->view->assign('userGroupsEdit', $this->userGroups->getItemsFromModelSelected($accountPermission->getUserGroupsEdit()));
+        $this->view->assign('mainUsergroupId', $this->userGroups->getItemsFromModelSelected(array($accountPermission->getMainUsergroupId())));
     }
 
     /**

--- a/app/modules/web/Forms/ItemsPresetForm.php
+++ b/app/modules/web/Forms/ItemsPresetForm.php
@@ -128,6 +128,7 @@ final class ItemsPresetForm extends FormBase implements FormInterface
         $accountPermission->setUsersEdit($this->request->analyzeArray('users_edit', null, []));
         $accountPermission->setUserGroupsView($this->request->analyzeArray('user_groups_view', null, []));
         $accountPermission->setUserGroupsEdit($this->request->analyzeArray('user_groups_edit', null, []));
+        $accountPermission->setMainUsergroupId($this->request->analyzeInt('main_usergroup_id'));
 
         if (!$accountPermission->hasItems()) {
             throw new ValidationException(__u('There aren\'t any defined permissions'));

--- a/app/modules/web/themes/material-blue/views/itemshow/item_preset-permission.inc
+++ b/app/modules/web/themes/material-blue/views/itemshow/item_preset-permission.inc
@@ -99,5 +99,23 @@ use SP\Mvc\View\Template;
             </div>
         </td>
     </tr>
+	<tr>
+        <td class="descField"><?php echo __('Main Group'); ?></td>
+        <td class="valField">
+            <div class="account-permissions">
+                <select id="main_usergroup_id" name="main_usergroup_id"
+                        class="select-box">
+                    <option value=""><?php echo __('Select Groups'); ?></option>
+                    <?php /** @var SelectItem $userGroup */
+                    foreach ($_getvar('mainUsergroupId') as $userGroup): ?>
+                        <?php if ($userGroup->isSkip()): continue; endif; ?>
+                        <option
+                                value="<?php echo $userGroup->getId(); ?>"
+                            <?php echo $userGroup->isSelected() ? 'selected' : '' ?>><?php echo $userGroup->getName(); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </td>
+    </tr>
     </tbody>
 </table>

--- a/lib/SP/DataModel/ItemPreset/AccountPermission.php
+++ b/lib/SP/DataModel/ItemPreset/AccountPermission.php
@@ -47,6 +47,10 @@ class AccountPermission
      * @var array
      */
     private $userGroupsEdit = [];
+    /**
+     * @var int
+     */
+    private $mainUsergroupId = 0;
 
     /**
      * @return array
@@ -129,6 +133,22 @@ class AccountPermission
     }
 
     /**
+     * @return int
+     */
+    public function getMainUsergroupId()
+    {
+        return (int)$this->mainUsergroupId;
+    }
+
+    /**
+     * @param int $mainUsergroupId
+     */
+    public function setMainUsergroupId($mainUsergroupId)
+    {
+        $this->mainUsergroupId = (int)$mainUsergroupId;
+    }
+
+    /**
      * @return bool
      */
     public function hasItems()
@@ -136,6 +156,7 @@ class AccountPermission
         return count($this->usersView) > 0
             || count($this->usersEdit) > 0
             || count($this->userGroupsView) > 0
-            || count($this->userGroupsEdit) > 0;
+            || count($this->userGroupsEdit) > 0
+            || $this->mainUsergroupId !== 0;
     }
 }

--- a/lib/SP/Services/Account/AccountService.php
+++ b/lib/SP/Services/Account/AccountService.php
@@ -209,7 +209,7 @@ final class AccountService extends Service implements AccountServiceInterface
             $accountRequest->key = $pass['key'];
         }
 
-        $this->setPresetPrivate($accountRequest);
+        $this->setPresetPrivatePermissions($accountRequest);
 
         $accountRequest->id = $this->accountRepository->create($accountRequest);
 
@@ -261,7 +261,7 @@ final class AccountService extends Service implements AccountServiceInterface
      * @throws NoSuchPropertyException
      * @throws NoSuchItemException
      */
-    private function setPresetPrivate(AccountRequest $accountRequest)
+    private function setPresetPrivatePermissions(AccountRequest $accountRequest)
     {
         $userData = $this->context->getUserData();
         $itemPreset = $this->itemPresetService->getForCurrentUser(ItemPresetInterface::ITEM_TYPE_ACCOUNT_PRIVATE);
@@ -285,6 +285,17 @@ final class AccountService extends Service implements AccountServiceInterface
                 $accountRequest->isPrivateGroup = (int)$accountPrivate->isPrivateGroup();
             }
         }
+
+        $itemPresetData = $this->itemPresetService->getForCurrentUser(ItemPresetInterface::ITEM_TYPE_ACCOUNT_PERMISSION);
+
+        if ($itemPresetData !== null
+            && $itemPresetData->getFixed()
+        ) {
+            $accountPermission = $itemPresetData->hydrate(AccountPermission::class);
+
+            $accountRequest->userGroupId = (int)$accountPermission->getMainUsergroupId();
+        }
+
     }
 
     /**
@@ -456,7 +467,7 @@ final class AccountService extends Service implements AccountServiceInterface
 
             $this->addHistory($accountRequest->id);
 
-            $this->setPresetPrivate($accountRequest);
+            $this->setPresetPrivatePermissions($accountRequest);
 
             $this->accountRepository->update($accountRequest);
 


### PR DESCRIPTION
Hey folks,
this pull request adds the possibility to define a "Main Group" via the permission preset. So you can achieve that you can add a fixed "Main Group" to all accounts.
Maybe the whole thing is interesting for someone else :-)

### It looks like this:

Accessible via "Preset values" and the option "Permission Preset":

![image](https://user-images.githubusercontent.com/18245229/79124976-aaf8f000-7d9d-11ea-82c4-8dee4a6563b5.png)

---

Now you can select a "Main Group" in the "Permission Preset" tab, which will then become the default for the selected Users, Groups or Profiles. If you select the "Forced" option in the "General" tab, every account will always be added to this "Main Group":

![image](https://user-images.githubusercontent.com/18245229/79125066-ccf27280-7d9d-11ea-9203-056b0e9647bf.png)
