### PR TITLE
[FIX] Fixes issue with LDAP pagination

### DIFF
--- a/lib/SP/Providers/Auth/Ldap/LdapActions.php
+++ b/lib/SP/Providers/Auth/Ldap/LdapActions.php
@@ -203,7 +203,7 @@ final class LdapActions
                 $searchRes,
                 $cookie
             );
-        } while ($cookie !== null && $cookie != '');
+        } while (!empty($cookie) && $entries["count"] > 0);
 
         return $results;
     }


### PR DESCRIPTION
Fixes #1564, don't know how to test this though without ldap server

For some reason the method ldap_control_paged_result_response
does not update the cookie correctly, so the pagination is not stopped.
It probably has a reason that this method is deprecated now...

This is a temporary fix until support for php 7.2 is dropped since the
new way to paginate is only supported since 7.3:
https://www.php.net/manual/en/ldap.examples-controls.php#example-5599