### PR TITLE
[FIX] issue_1174 (Prepared statment Needs to be re-prepared)

### DIFF
--- a/lib/SP/Storage/Database/MySQLHandler.php
+++ b/lib/SP/Storage/Database/MySQLHandler.php
@@ -111,7 +111,7 @@ final class MySQLHandler implements DBStorageInterface
 
                 // Set prepared statement emulation depending on server version
                 $serverVersion = $this->db->getAttribute(PDO::ATTR_SERVER_VERSION);
-                $this->db->setAttribute(PDO::ATTR_EMULATE_PREPARES, version_compare($serverVersion, '5.1.17', '<'));
+                $this->db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
                 $this->dbStatus = self::STATUS_OK;
             } catch (Exception $e) {


### PR DESCRIPTION
Permanent fix for issue 1174 (https://github.com/nuxsmin/sysPass/issues/1174)
 - This commit fixes the `SQLSTATA[HY000]: General error: 1615 Prepared statment Needs to be re-prepared` error which occurs after a clean installation with a recent version of MariaDB.