### PR TITLE
* [FIX] Fix ADS search behavior by unsseting `ACCOUNTDISABLE` flag fo…

### DIFF
--- a/lib/SP/Providers/Auth/Ldap/LdapMsAds.php
+++ b/lib/SP/Providers/Auth/Ldap/LdapMsAds.php
@@ -38,7 +38,7 @@ use SP\Http\Address;
  */
 final class LdapMsAds extends Ldap
 {
-    const FILTER_USER_OBJECT = '(&(!(UserAccountControl:1.2.840.113556.1.4.804:=30))(|(objectCategory=person)(objectClass=user)))';
+    const FILTER_USER_OBJECT = '(&(!(UserAccountControl:1.2.840.113556.1.4.804:=32))(|(objectCategory=person)(objectClass=user)))';
     const FILTER_GROUP_OBJECT = '(objectCategory=group)';
     const FILTER_USER_ATTRIBUTES = ['samaccountname', 'cn', 'uid', 'userPrincipalName'];
     const FILTER_GROUP_ATTRIBUTES = ['memberOf', 'groupMembership', 'memberof:1.2.840.113556.1.4.1941:'];


### PR DESCRIPTION
…r `UserAccountControl` property, since it prevents to throw the proper status code when authenticating against LDAP. Thanks to @t0l0 for testing. Closes #1574

* [MOD] Update dependencies
* [MOD] Bump version number

Signed-off-by: Rubén D <nuxsmin@syspass.org>