### PR TITLE
[FIX] Missing LdapTlsEnabled config on sign-in

### DIFF
--- a/lib/SP/Providers/Auth/AuthProvider.php
+++ b/lib/SP/Providers/Auth/AuthProvider.php
@@ -145,7 +145,8 @@ final class AuthProvider extends Provider
             ->setGroup($this->configData->getLdapGroup())
             ->setBindDn($this->configData->getLdapBindUser())
             ->setBindPass($this->configData->getLdapBindPass())
-            ->setType($this->configData->getLdapType());
+            ->setType($this->configData->getLdapType())
+            ->setTlsEnabled($this->configData->isLdapTlsEnabled());
 
         return new LdapAuth(
             Ldap::factory(


### PR DESCRIPTION
When using ldap with starttls, import succeeds on config page but sign-in fails.
LdapTlsEnabled config is not passed to LdapParams on sign-in.